### PR TITLE
Feature: Kubernetes-ready : added file structure to add it to LogAggregator service - https://git…

### DIFF
--- a/kube/dns-resolver-configmap.yaml
+++ b/kube/dns-resolver-configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dns-resolver-config
+  labels:
+    app: dns-resolver
+data:
+  config.json : |
+    {
+      "LogAggregator": {
+          "protocol": "http",
+          "host": "log-aggregator-service",
+          "port": 3001,
+          "endpoint": "/log",
+          "username" : <logAggregatorUser>,
+          "password" : <logAggregatorUserPassword>,
+          "login": "/auth/login"
+      },
+
+      "logFile" : "",
+
+      "logSchedule" : {
+          "days": 0,
+          "hours": 0,
+          "mins": 0.5
+      }
+    }

--- a/kube/dns-resolver.yaml
+++ b/kube/dns-resolver.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-resolver
+  namespace: default
+  labels:
+    app: dns-resolver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dns-resolver
+  template:
+    metadata:
+      labels:
+        app: dns-resolver
+    spec:
+      containers:
+      - name: dns-resolver-container
+        image: simasgrilo/dns-resolver:latest
+        imagePullPolicy: Always
+        volumeMounts:
+          - name:  dns-resolver-config
+            mountPath:  '/app/config.json' 
+            subPath: config.json
+        ports:
+        - containerPort: 5000
+          protocol: TCP
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "250m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+      volumes:
+        - name: dns-resolver-config
+          configMap : 
+            name: dns-resolver-config
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name:  dns-resolver-service
+spec:
+  selector:
+    app:  dns-resolver
+  type:   NodePort
+  ports:
+  - protocol: TCP
+    port:  3000
+    targetPort:  5000
+    nodePort: 30000
+


### PR DESCRIPTION

# Tl;dr
Setup Kubernetes files to allow using this service Kubernetes deployment

# Context
This change enables the usage of DNSResolvr from within a Kubernetes cluster by just applying the files added. Note that the configmap contains information to be used along with [LogAggregator](

# Test Plan
Setup a local Kubernetes cluster
run ```kubectl port-forward service/dns-resolver-service 3000``` and try it locally with your favorite REST API client (Postman/Insomnia, etc.)